### PR TITLE
feat: button group closes #16

### DIFF
--- a/packages/styles/core/components/button.styl
+++ b/packages/styles/core/components/button.styl
@@ -95,6 +95,7 @@
         background-color $Destructive700
 
     &:focus
+      z-index 1
       focus-ring()
 
     &:disabled

--- a/packages/styles/core/components/buttonGroup.styl
+++ b/packages/styles/core/components/buttonGroup.styl
@@ -1,0 +1,18 @@
+.blank
+    &__button-group
+        flex(row, justify-center, align-center, flex)
+
+        .blank__button
+            border-radius 0
+
+            &:first-child
+                border-top-left-radius 12px
+                border-bottom-left-radius 12px
+
+            &:last-child
+                border-top-right-radius 12px
+                border-bottom-right-radius 12px
+
+            &:nth-child(2)
+                border-left 0
+                border-right 0

--- a/packages/styles/core/components/index.styl
+++ b/packages/styles/core/components/index.styl
@@ -1,2 +1,3 @@
 @import 'button.styl'
+@import 'buttonGroup.styl'
 @import 'container.styl'

--- a/packages/vue/core/components/button.vue
+++ b/packages/vue/core/components/button.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ButtonProps } from '@blank/types'
-import { computed } from 'vue'
+import { computed, inject, onMounted, ref } from 'vue'
 import Icon from '../common/icon.vue'
 
 const props = withDefaults(defineProps<ButtonProps>(), {
@@ -10,17 +10,31 @@ const props = withDefaults(defineProps<ButtonProps>(), {
 	disabled: false,
 })
 
-const classes = computed(() => {
-	return {
-		[props.appearance]: true,
-		[props.variant]: true,
-		[props.size]: true,
+const variant = ref(props.variant)
+const size = ref(props.size)
+const appearance = ref(props.appearance)
+
+const buttonGroup = inject('buttonGroup') as {
+	size: 'small' | 'medium' | 'large'
+}
+
+onMounted(() => {
+	if (buttonGroup) {
+		size.value = buttonGroup.size || size.value
+		variant.value = 'secondary'
+		appearance.value = 'default'
 	}
 })
+
+const classes = computed(() => ({
+	[appearance.value]: true,
+	[variant.value]: true,
+	[size.value]: true,
+}))
 </script>
 
 <template>
-	<button class="blank__button" :class="classes" :disabled="disabled">
+	<button class="blank__button" :class="classes" :disabled="props.disabled">
 		<slot />
 	</button>
 </template>

--- a/packages/vue/core/components/buttonGroup.vue
+++ b/packages/vue/core/components/buttonGroup.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { ButtonGroupProps } from '@blank/types'
+import { provide } from 'vue'
+
+const props = withDefaults(defineProps<ButtonGroupProps>(), {
+	size: 'medium',
+})
+
+provide('buttonGroup', {
+	size: props.size,
+})
+</script>
+
+<template>
+	<div class="blank__button-group">
+		<slot />
+	</div>
+</template>

--- a/packages/vue/core/components/index.ts
+++ b/packages/vue/core/components/index.ts
@@ -1,1 +1,2 @@
 export { default as Button } from './button.vue'
+export { default as ButtonGroup } from './buttonGroup.vue'

--- a/playground/vue/src/index.vue
+++ b/playground/vue/src/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Button, Container, Icon, Logos } from '@blank/vue'
+import { Button, ButtonGroup, Container, Icon, Logos } from '@blank/vue'
 </script>
 
 <template>
@@ -29,5 +29,38 @@ import { Button, Container, Icon, Logos } from '@blank/vue'
 		</Button>
 
 		<Logos name="company:figma" size="small" />
+		<div>
+			<ButtonGroup size="small">
+				<Button>
+					Primary
+				</Button>
+				<Button>
+					Quaternary
+				</Button>
+			</ButtonGroup>
+		</div>
+		<div>
+			<ButtonGroup>
+				<Button>
+					Primary
+				</Button>
+				<Button>
+					Quaternary
+				</Button>
+			</ButtonGroup>
+		</div>
+		<div>
+			<ButtonGroup size="large">
+				<Button>
+					Primary
+				</Button>
+				<Button>
+					Primary
+				</Button>
+				<Button>
+					Quaternary
+				</Button>
+			</ButtonGroup>
+		</div>
 	</Container>
 </template>

--- a/shared/types/src/components/buttonGroups.ts
+++ b/shared/types/src/components/buttonGroups.ts
@@ -1,0 +1,5 @@
+interface ButtonGroupProps {
+    size: 'small' | 'medium' | 'large'
+}
+
+export type { ButtonGroupProps }

--- a/shared/types/src/components/buttonGroups.ts
+++ b/shared/types/src/components/buttonGroups.ts
@@ -1,5 +1,5 @@
 interface ButtonGroupProps {
-    size: 'small' | 'medium' | 'large'
+    size?: 'small' | 'medium' | 'large'
 }
 
 export type { ButtonGroupProps }

--- a/shared/types/src/components/index.ts
+++ b/shared/types/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './button'
+export * from './buttonGroups'


### PR DESCRIPTION
This pull request introduces a new `ButtonGroup` component and updates related files to support this new feature. It also includes enhancements to the `Button` component to integrate with the `ButtonGroup`.

### New `ButtonGroup` Component:

* [`packages/styles/core/components/buttonGroup.styl`](diffhunk://#diff-dff379ceaac7d128043d41baa7efc71f7b8656b1322a8fcfe939467e17c43cf7R1-R18): Added styles for the `ButtonGroup` component, including flexbox layout and border-radius adjustments for buttons within the group.
* [`packages/vue/core/components/buttonGroup.vue`](diffhunk://#diff-cb21357dd3d65c1c501f878ef4ee09946c08d85248e2c02bd6fdf19ac6233d12R1-R18): Created the `ButtonGroup` component with a `size` prop and provided this context to child buttons.
* [`packages/vue/core/components/index.ts`](diffhunk://#diff-4b24f5b1a2f48e63fe9863bb458a4d882202ee3e1d17fc91945573bff64d8d50R2): Exported the new `ButtonGroup` component.
* [`shared/types/src/components/buttonGroups.ts`](diffhunk://#diff-005a4c364ee31768028dfddf7e2ab8e8076156b8571ae0f80f25ce54f539b08eR1-R5): Defined the `ButtonGroupProps` interface.
* [`shared/types/src/components/index.ts`](diffhunk://#diff-4d067315b8acfc4757a455d12350f792835e9ca372ebbfd1ed92709e81b3df0fR2): Exported the `ButtonGroupProps` interface.

### Updates to `Button` Component:

* [`packages/vue/core/components/button.vue`](diffhunk://#diff-1f989b4906d7c4d38bf38be9870e40177a5ee6fe639d071f3c7a8d4176658debL3-R3): Modified the `Button` component to use `inject` for receiving `ButtonGroup` context and updated class bindings accordingly. [[1]](diffhunk://#diff-1f989b4906d7c4d38bf38be9870e40177a5ee6fe639d071f3c7a8d4176658debL3-R3) [[2]](diffhunk://#diff-1f989b4906d7c4d38bf38be9870e40177a5ee6fe639d071f3c7a8d4176658debL13-R37)

### Integration and Testing:

* [`playground/vue/src/index.vue`](diffhunk://#diff-004656d3c60c33a27dcc69a04462b6e8d4d70ef3986f6fada7be388342015426L2-R2): Added examples of the `ButtonGroup` component with different sizes to the playground for testing and demonstration. [[1]](diffhunk://#diff-004656d3c60c33a27dcc69a04462b6e8d4d70ef3986f6fada7be388342015426L2-R2) [[2]](diffhunk://#diff-004656d3c60c33a27dcc69a04462b6e8d4d70ef3986f6fada7be388342015426R32-R64)

### Minor Style Update:

* [`packages/styles/core/components/button.styl`](diffhunk://#diff-ae433a3ac7a7a872d9f295697f88e6ac4416fe9ce263b3628734d76d66bd1d92R98): Added `z-index` to the focused state of the button.

### Import Adjustments:

* [`packages/styles/core/components/index.styl`](diffhunk://#diff-d2fcb60bbf88139a91bccb29d41e0b52d8277c37237f10e22afd2b407c219dcdR2): Imported the new `buttonGroup.styl` file.